### PR TITLE
Fix for Jumpcloud command for group movement of devices that are MDM enrolled from DEP

### DIFF
--- a/JumpCloudImporter.py
+++ b/JumpCloudImporter.py
@@ -704,7 +704,7 @@ systemGroupID="{2}"
 systemGroupPostID="{3}"
 userAgent="{4}"
 JCAPIKey='{5}'
-JCOrgID'{6}'
+JCOrgID='{6}'
 
 # Parse the systemKey from the conf file.
 conf="$(cat /opt/jc/jcagent.conf)"
@@ -722,38 +722,29 @@ fi
 # Get the current time.
 now=$(date -u "+%a, %d %h %Y %H:%M:%S GMT")
 
-curl -s \
-    -X 'POST' \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json' \
-    -H "Date: ${now}" \
-    -H 'x-api-key: '${JCAPIKey}'' \
-    -H 'x-org-id: '${JCOrgID}'' \
-    -d '{"op": "remove","type": "system","id": "'${systemID}'"}' \
-        "https://console.jumpcloud.com/api/v2/systemgroups/${systemGroupID}/members"
+curl -s \\
+    -X 'POST' \\
+    -H 'Content-Type: application/json' \\
+    -H 'Accept: application/json' \\
+    -H "Date: ${{now}}" \\
+    -H 'x-api-key: '${{JCAPIKey}}'' \\
+    -H 'x-org-id: '${{JCOrgID}}'' \\
+    -d '{{"op": "remove","type": "system","id": "'${{systemID}}'"}}' \\
+        "https://console.jumpcloud.com/api/v2/systemgroups/${{systemGroupID}}/members"
 
-echo "JumpCloud system: ${systemID} removed from system group: ${systemGroupID}"
+echo "JumpCloud system: ${{systemID}} removed from system group: ${{systemGroupID}}"
 
-# Get the current time.
-now=$(date -u "+%a, %d %h %Y %H:%M:%S GMT")
+curl -s \\
+    -X 'POST' \\
+    -H 'Content-Type: application/json' \\
+    -H 'Accept: application/json' \\
+    -H "Date: ${{now}}" \\
+    -H 'x-api-key: '${{JCAPIKey}}'' \\
+    -H 'x-org-id: '${{JCOrgID}}'' \\
+    -d '{{"op": "add","type": "system","id": "'${{systemID}}'"}}' \\
+        "https://console.jumpcloud.com/api/v2/systemgroups/${{systemGroupPostID}}/members"
 
-# create the string to sign from the request-line and the date
-signstr="POST /api/v2/systemgroups/${systemGroupPostID}/members HTTP/1.1\ndate: ${now}"
-
-# create the signature
-signature=$(printf "$signstr" | openssl dgst -sha256 -sign /opt/jc/client.key | openssl enc -e -a | tr -d '\n')
-
-curl -s \
-    -X 'POST' \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json' \
-    -H "Date: ${now}" \
-    -H 'x-api-key: '${JCAPIKey}'' \
-    -H 'x-org-id: '${JCOrgID}'' \
-    -d '{"op": "add","type": "system","id": "'${systemID}'"}' \
-        "https://console.jumpcloud.com/api/v2/systemgroups/${systemGroupPostID}/members"
-
-echo "JumpCloud system: ${systemID} added to post install system group: ${systemGroupPostID}"
+echo "JumpCloud system: ${{systemID}} added to post install system group: ${{systemGroupPostID}}"
 exit 0
 ''')
         userAgent = "JumpCloud_" + "autopkg-importer/" + __version__

--- a/JumpCloudImporter.py
+++ b/JumpCloudImporter.py
@@ -703,65 +703,62 @@ installer -pkg "/tmp/{0}" -target /
 systemGroupID="{2}"
 systemGroupPostID="{3}"
 userAgent="{4}"
+JCAPIKey="{5}"
+JCOrgID="{6}"
 
 # Parse the systemKey from the conf file.
 conf="$(cat /opt/jc/jcagent.conf)"
-regex='\"systemKey\":\"[a-zA-Z0-9]{{24}}\"'
+regex='"systemKey":"[a-zA-Z0-9]{24}"'
 
 if [[ $conf =~ $regex ]]; then
-	systemKey="${{BASH_REMATCH[@]}}"
+	systemKey="${BASH_REMATCH[@]}"
 fi
 
-regex='[a-zA-Z0-9]{{24}}'
+regex='[a-zA-Z0-9]{24}'
 if [[ $systemKey =~ $regex ]]; then
-	systemID="${{BASH_REMATCH[@]}}"
+	systemID="${BASH_REMATCH[@]}"
 fi
 
 # Get the current time.
 now=$(date -u "+%a, %d %h %Y %H:%M:%S GMT")
 
-# create the string to sign from the request-line and the date
-signstr="POST /api/v2/systemgroups/${{systemGroupID}}/members HTTP/1.1\\ndate: ${{now}}"
+curl -s \
+	-X 'POST' \
+	-H 'Content-Type: application/json' \
+	-H 'Accept: application/json' \
+	-H "Date: ${now}" \
+	-H 'x-api-key: '${JCAPIKey}'' \
+  	-H 'x-org-id: '${JCOrgID}'' \
+	-d '{"op": "remove","type": "system","id": "'${systemID}'"}' \
+        "https://console.jumpcloud.com/api/v2/systemgroups/${systemGroupID}/members"
 
-# create the signature
-signature=$(printf "$signstr" | openssl dgst -sha256 -sign /opt/jc/client.key | openssl enc -e -a | tr -d '\\n')
-
-curl -s \\
-	-X 'POST' \\
-	-H 'Content-Type: application/json' \\
-	-H 'Accept: application/json' \\
-	-H "Date: ${{now}}" \\
-	-H "Authorization: Signature keyId=\\"system/${{systemID}}\\",headers=\\"request-line date\\",algorithm=\\"rsa-sha256\\",signature=\\"${{signature}}\\"" \\
-	-d '{{"op": "remove","type": "system","id": "'${{systemID}}'"}}' \\
-	"https://console.jumpcloud.com/api/v2/systemgroups/${{systemGroupID}}/members"
-
-echo "JumpCloud system: ${{systemID}} removed from system group: ${{systemGroupID}}"
+echo "JumpCloud system: ${systemID} removed from system group: ${systemGroupID}"
 
 # Get the current time.
 now=$(date -u "+%a, %d %h %Y %H:%M:%S GMT")
 
 # create the string to sign from the request-line and the date
-signstr="POST /api/v2/systemgroups/${{systemGroupPostID}}/members HTTP/1.1\\ndate: ${{now}}"
+signstr="POST /api/v2/systemgroups/${systemGroupPostID}/members HTTP/1.1\ndate: ${now}"
 
 # create the signature
-signature=$(printf "$signstr" | openssl dgst -sha256 -sign /opt/jc/client.key | openssl enc -e -a | tr -d '\\n')
+signature=$(printf "$signstr" | openssl dgst -sha256 -sign /opt/jc/client.key | openssl enc -e -a | tr -d '\n')
 
-curl -s \\
-	-X 'POST' \\
-	-A "${{userAgent}}" \\
-	-H 'Content-Type: application/json' \\
-	-H 'Accept: application/json' \\
-	-H "Date: ${{now}}" \\
-	-H "Authorization: Signature keyId=\\"system/${{systemID}}\\",headers=\\"request-line date\\",algorithm=\\"rsa-sha256\\",signature=\\"${{signature}}\\"" \\
-	-d '{{"op": "add","type": "system","id": "'${{systemID}}'"}}' \\
-	"https://console.jumpcloud.com/api/v2/systemgroups/${{systemGroupPostID}}/members"
+curl -s \
+	-X 'POST' \
+	-H 'Content-Type: application/json' \
+	-H 'Accept: application/json' \
+	-H "Date: ${now}" \
+	-H 'x-api-key: '${JCAPIKey}'' \
+  	-H 'x-org-id: '${JCOrgID}'' \
+	-d '{"op": "add","type": "system","id": "'${systemID}'"}' \
+		"https://console.jumpcloud.com/api/v2/systemgroups/${systemGroupPostID}/members"
 
-echo "JumpCloud system: ${{systemID}} added to post install system group: ${{systemGroupPostID}}"
+echo "JumpCloud system: ${systemID} added to post install system group: ${systemGroupPostID}"
 exit 0
 ''')
         userAgent = "JumpCloud_" + "autopkg-importer/" + __version__
         query = query.format(
-            object_name, url, self.systemGroupID, self.systemGroupPostID, userAgent)
+            object_name, url, self.systemGroupID, self.systemGroupPostID, userAgent, self.API_KEY, self.ORG_ID)
         usr = self.env["JC_USER"]
         # files uploaded in list[str] format where str is an ID of a JumpCloud
         # file variable for selecting the AutoPkg package path

--- a/JumpCloudImporter.py
+++ b/JumpCloudImporter.py
@@ -703,33 +703,33 @@ installer -pkg "/tmp/{0}" -target /
 systemGroupID="{2}"
 systemGroupPostID="{3}"
 userAgent="{4}"
-JCAPIKey="{5}"
-JCOrgID="{6}"
+JCAPIKey='{5}'
+JCOrgID'{6}'
 
 # Parse the systemKey from the conf file.
 conf="$(cat /opt/jc/jcagent.conf)"
-regex='"systemKey":"[a-zA-Z0-9]{24}"'
+regex='\"systemKey\":\"[a-zA-Z0-9]{{24}}\"'
 
 if [[ $conf =~ $regex ]]; then
-	systemKey="${BASH_REMATCH[@]}"
+    systemKey="${{BASH_REMATCH[@]}}"
 fi
 
-regex='[a-zA-Z0-9]{24}'
+regex='[a-zA-Z0-9]{{24}}'
 if [[ $systemKey =~ $regex ]]; then
-	systemID="${BASH_REMATCH[@]}"
+    systemID="${{BASH_REMATCH[@]}}"
 fi
 
 # Get the current time.
 now=$(date -u "+%a, %d %h %Y %H:%M:%S GMT")
 
 curl -s \
-	-X 'POST' \
-	-H 'Content-Type: application/json' \
-	-H 'Accept: application/json' \
-	-H "Date: ${now}" \
-	-H 'x-api-key: '${JCAPIKey}'' \
-  	-H 'x-org-id: '${JCOrgID}'' \
-	-d '{"op": "remove","type": "system","id": "'${systemID}'"}' \
+    -X 'POST' \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json' \
+    -H "Date: ${now}" \
+    -H 'x-api-key: '${JCAPIKey}'' \
+    -H 'x-org-id: '${JCOrgID}'' \
+    -d '{"op": "remove","type": "system","id": "'${systemID}'"}' \
         "https://console.jumpcloud.com/api/v2/systemgroups/${systemGroupID}/members"
 
 echo "JumpCloud system: ${systemID} removed from system group: ${systemGroupID}"
@@ -744,14 +744,14 @@ signstr="POST /api/v2/systemgroups/${systemGroupPostID}/members HTTP/1.1\ndate: 
 signature=$(printf "$signstr" | openssl dgst -sha256 -sign /opt/jc/client.key | openssl enc -e -a | tr -d '\n')
 
 curl -s \
-	-X 'POST' \
-	-H 'Content-Type: application/json' \
-	-H 'Accept: application/json' \
-	-H "Date: ${now}" \
-	-H 'x-api-key: '${JCAPIKey}'' \
-  	-H 'x-org-id: '${JCOrgID}'' \
-	-d '{"op": "add","type": "system","id": "'${systemID}'"}' \
-		"https://console.jumpcloud.com/api/v2/systemgroups/${systemGroupPostID}/members"
+    -X 'POST' \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json' \
+    -H "Date: ${now}" \
+    -H 'x-api-key: '${JCAPIKey}'' \
+    -H 'x-org-id: '${JCOrgID}'' \
+    -d '{"op": "add","type": "system","id": "'${systemID}'"}' \
+        "https://console.jumpcloud.com/api/v2/systemgroups/${systemGroupPostID}/members"
 
 echo "JumpCloud system: ${systemID} added to post install system group: ${systemGroupPostID}"
 exit 0


### PR DESCRIPTION
This implementation is meant to fix errors from the Jumpcloud Console that say the API request is unauthorized.

"Systems that have been automatically enrolled using Apple's Device Enrollment Program (DEP) or systems enrolled using the User Portal install are not eligible to use the System Context API to prevent unauthorized access to system groups and resources. If a script that utilizes the System Context API is invoked on a system enrolled in this way, it will display an error." - Jumpcloud API Documentation